### PR TITLE
Optimization of optical conductivity (__kubo.py)

### DIFF
--- a/wannierberri/__kubo.py
+++ b/wannierberri/__kubo.py
@@ -19,7 +19,7 @@ import numpy as np
 from scipy import constants as constants
 from collections import Iterable
 import functools
-from termcolor import cprint 
+from termcolor import cprint
 
 from . import __result as result
 
@@ -34,7 +34,7 @@ def Lorentzian(x, width):
 def Gaussian(x, width):
     arg = np.minimum(200.0, (x/width)**2)
     return 1.0/(np.sqrt(pi) * width) * np.exp(-1*arg)
-    
+
 # Fermi-Dirac distribution
 def FermiDirac(E, mu, kBT):
     if kBT == 0:
@@ -48,7 +48,7 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
                 adpt_smr_fac=np.sqrt(2), adpt_smr_max=0.1, adpt_smr_min=1e-15):
     '''
     Calculates the optical conductivity according to the Kubo-Greenwood formula.
-    
+
     Arguments:
         data            instance of __data_dk.Data_dk representing a single point in the BZ
         omega           value or list of frequencies in units of eV/hbar
@@ -60,11 +60,11 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
         adpt_smr_fac    prefactor for the adaptive smearing parameter
         adpt_smr_max    maximal value of the adaptive smearing parameter
         adpt_smr_min    minimal value of the adaptive smearing parameter
-        
+
     Returns:    a list of (complex) optical conductivity 3 x 3 tensors (one for each frequency value).
                 The result is given in S/cm.
     '''
-    
+
     # data gives results in terms of
     # ik = index enumerating the k points in Data_dk object
     # m,n = indices enumerating the eigenstates/eigenvalues of H(k)
@@ -72,35 +72,35 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
     # additionally the result will include
     # iw = index enumerating the frequency values
     # ri = index for real and imaginary parts (0 -> real, 1 -> imaginary)
-    
+
     # TODO: optimize for T = 0? take only necessary elements
-    
+
     # prefactor for correct units of the result (S/cm)
     pre_fac = e**2/(100.0 * hbar * data.NKFFT_tot * data.cell_volume * constants.angstrom)
-    
+
     # frequency
     if not isinstance(omega, Iterable):
         omega = np.array([omega])
-        
+
     sigma_H = np.zeros((omega.shape[0], 3, 3), dtype=np.dtype('complex128'))
     sigma_AH = np.zeros((omega.shape[0], 3, 3), dtype=np.dtype('complex128'))
-        
+
     # iterate over ik
     for ik in range(data.NKFFT_tot):
         # energy
         E = data.E_K[ik] # energies [n] in eV
         dE = E[np.newaxis,:] - E[:, np.newaxis] # E_m(k) - E_n(k) [n, m]
-        
+
          # occupation
         fE = FermiDirac(E, mu, kBT) # f(E_m(k)) - f(E_n(k)) [n]
         dfE = fE[np.newaxis,:] - fE[:, np.newaxis] # [n, m]
-        
+
         # generalized Berry connection matrix
         A = data.A_H[ik] # [n, m, a] in angstrom
-       
+
         # E - omega
         delta_arg = dE - omega[:, np.newaxis, np.newaxis] # argument of delta function [iw, n, m]
-        
+
         # smearing
         if adpt_smr: # [iw, n, m]
             cprint("Adaptive smearing is an experimental feature and has not been extensively tested.", 'orange')
@@ -121,28 +121,28 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
         else:
             cprint("Invalid smearing type. Fallback to Lorentzian", 'orange')
             delta = Lorentzian(delta_arg, eta)
-        
+
         sigma_H += -1 * pi * pre_fac * np.einsum('nm,nm,nma,mnb,wnm->wab', dfE, dE, A, A, delta) # [iw, a, b]
-        
+
         # free memory
         del delta
-        
-        
+
+
         # anti-Hermitian part of the conductivity tensor
         re_efrac = delta_arg/(delta_arg**2 + eta**2) # real part of energy fraction [iw, n, m]
         sigma_AH += 1j * pre_fac * np.einsum('nm,nm,wnm,nma,mnb->wab', dfE, dE, re_efrac, A, A) # [iw, a, b]
-        
+
         # free memory
         del re_efrac
         del delta_arg
         del dfE
         del dE
-        
+
     # TODO: optimize by just storing independent components or leave it like that?
     # 3x3 tensors [iw, a, b]
     sigma_sym = np.real(sigma_H) + 1j * np.imag(sigma_AH) # symmetric (TR-even, I-even)
     sigma_asym = np.real(sigma_AH) + 1j * np.imag(sigma_H) # ansymmetric (TR-odd, I-even)
-    
+
     # return result dictionary
     return result.EnergyResultDict({
         'sym':  result.EnergyResult(omega, sigma_sym, TRodd=False, Iodd=False, rank=2),

--- a/wannierberri/__kubo.py
+++ b/wannierberri/__kubo.py
@@ -32,8 +32,12 @@ hbar = constants.hbar
 def Lorentzian(x, width):
     return 1.0/(pi*width) * width**2/(x**2 + width**2)
 def Gaussian(x, width):
-    arg = np.minimum(200.0, (x/width)**2)
-    return 1.0/(np.sqrt(pi) * width) * np.exp(-1*arg)
+    # Compute 1 / (np.sqrt(pi) * width) * exp(-(x / width) ** 2)
+    # If the exponent is less than -200, return 0.
+    inds = abs(x) < width * np.sqrt(200.0)
+    output = np.zeros_like(x)
+    output[inds] = 1.0 / (np.sqrt(pi) * width) * np.exp(-(x[inds] / width)**2)
+    return output
 
 # Fermi-Dirac distribution
 def FermiDirac(E, mu, kBT):

--- a/wannierberri/__kubo.py
+++ b/wannierberri/__kubo.py
@@ -117,7 +117,7 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
 
         # smearing
         if adpt_smr: # [iw, n, m]
-            cprint("Adaptive smearing is an experimental feature and has not been extensively tested.", 'orange')
+            cprint("Adaptive smearing is an experimental feature and has not been extensively tested.", 'red')
             eta = smr_fixed_width
             delE = data.delE_K[ik] # energy derivatives [n, a] in eV*angstrom
             ddelE = delE[np.newaxis,:] - delE[:, np.newaxis] # delE_m(k) - delE_n(k) [n, m, a]
@@ -132,7 +132,7 @@ def opt_conductivity(data, omega=0, mu=0, kBT=0, smr_fixed_width=0.1, smr_type='
         elif smr_type == 'Gaussian':
             delta = Gaussian(delta_arg, eta)
         else:
-            cprint("Invalid smearing type. Fallback to Lorentzian", 'orange')
+            cprint("Invalid smearing type. Fallback to Lorentzian", 'red')
             delta = Lorentzian(delta_arg, eta)
 
         # real part of energy fraction [iw, n, m]


### PR DESCRIPTION
Dear developers,

This PR implements the optimization of the optical conductivity routine.

1) The bottleneck was the einsum call, which had many arguments. As Stepan suggested, I refactored this with smaller einsum and matmul calls.
2) The evaluation of Gaussian is optimized by computing only nonzero elements. np.exp(-x) is set to 0 for x > -200.

The runtime without and with the optimizations are the following.
* No optimization (master branch, 3513555): 69.76 sec
* Optimization 1: 8.26 sec
* Optimizations 1 and 2: 5.51 sec

I checked that the symmetric and asymmetric part of the optical conductivity of Fe computed with the old and new codes are identical up to numerical errors (error ~ 1E-12).

I also deleted the "# free memory" parts in __kubo.py. If they should be kept, I will put them again.

Best regards,
Jae-Mo Lihm
Seoul National University