### PR TITLE
WIP: Optimization of einsum in shc_B_H

### DIFF
--- a/wannierberri/__Data_K.py
+++ b/wannierberri/__Data_K.py
@@ -714,11 +714,25 @@ class Data_K(System):
         return self._R_to_k_H(self.SHA_R.copy(), hermitian=False)
 #PRB QZYZ18, Qiao's way to calculate SHC
 
+    def _shc_B_H_einsum_opt(self, C, A, B):
+        # Optimized version of C += np.einsum('knlc,klma->knmac', A, B). Used in shc_B_H.
+        nw = self.num_wann
+        for ik in range(self.nkptot):
+            # Performing C[ik] += np.einsum('nlc,lma->nmac', A[ik], B[ik])
+            tmp_a = np.swapaxes(A[ik], 1, 2) # nlc -> ncl
+            tmp_a = np.reshape(tmp_a, (nw*3, nw)) # ncl -> (nc)l
+            tmp_b = np.reshape(B[ik], (nw, nw*3)) # lma -> l(ma)
+            tmp_c = tmp_a @ tmp_b # (nc)l, l(ma) -> (nc)(ma)
+            tmp_c = np.reshape(tmp_c, (nw, 3, nw, 3)) # (nc)(ma) -> ncma
+            C[ik] += np.transpose(tmp_c, (0, 2, 3, 1)) # ncma -> nmac
+
     @lazy_property.LazyProperty
     def shc_B_H(self):
         SH_H = self._R_to_k_H(self.SH_R.copy(), hermitian=False)
-        shc_K_H = -1j*self._R_to_k_H(self.SR_R.copy(), hermitian=False) + np.einsum('knlc,klma->knmac', self.S_H, self.D_H)
-        shc_L_H = -1j*self._R_to_k_H(self.SHR_R.copy(), hermitian=False) + np.einsum('knlc,klma->knmac', SH_H, self.D_H)
+        shc_K_H = -1j*self._R_to_k_H(self.SR_R.copy(), hermitian=False)
+        self._shc_B_H_einsum_opt(shc_K_H, self.S_H, self.D_H)
+        shc_L_H = -1j*self._R_to_k_H(self.SHR_R.copy(), hermitian=False)
+        self._shc_B_H_einsum_opt(shc_L_H, SH_H, self.D_H)
         return (self.delE_K[:,np.newaxis,:,:,np.newaxis]*self.S_H[:,:,:,np.newaxis,:] +
             self.E_K[:,np.newaxis,:,np.newaxis,np.newaxis]*shc_K_H[:,:,:,:,:] - shc_L_H)
 #end SHC


### PR DESCRIPTION
I optimized `shc_B_H` by replacing `einsum` with matrix multiplication, transposing and reshaping. This improves the performance of opt_SHCqiao calculation.

Optimization of `einsum` reduces the time taken in `shc_B_H` is from 243s to 82s. After the optimization, the bottleneck is `_R_to_k_H` inside `shc_B_H`  (~50% of total time). See details below.

I checked with bulk Pt that the calculation result does not change after optimization.

This optimization was discussed in https://github.com/stepan-tsirkin/wannier-berri/pull/22#discussion_r532286534
I tried 1) using `einsum_path` and 2) factoring out the 'k' index from the einsum call (but still using einsum inside the loop). But, both did not give any speedup.

Dear @migueldiascosta, could you (or the user, Truman Ng Yu - I could not find the GitHub id) try this MR and double check its performance and correctness?

### Summary of the performance test
I used `num_wann=88`, `number of R points = 1163`, `SHCqiao=True`, `len(Efermi)=1`, `len(omega)=1`, `NKdiv=[1 1 1]`, and `NKFFT=[10 10 10]`. I used `kernprof` to profile the code.

If there are ~100 Efermi or omega, `kubo_sum_elements` becomes the bottleneck.
Note that `kubo_sum_elements` scales as O(N_W^2) while `_R_to_k_H` and `_shc_B_H_einsum_opt` scales as O(N_W^3). So, `shc_B_H` becomes more important when `N_W` is larger.

* Before/after optimization, `shc_B_H` takes 90%/76% of time.
* Optimization of `einsum` reduces the time taken in `shc_B_H` is from 243s to 82s.
* For the `einsum` lines, the speedup is from 180s to 20s.
* After optimization, `_R_to_k_H` of `SH_R`, `SR_R` and `SHR_R` takes ~57% of the total time. Optimized einsum takes ~17%. Calculation of `A_H` also takes ~17%.
* Inside `_shc_B_H_einsum_opt`, most (~90%) of the time is spent in the actual matrix multiplication.